### PR TITLE
Update FFmpegWrapper.c

### DIFF
--- a/FFmpegWrapper/jni/FFmpegWrapper.c
+++ b/FFmpegWrapper/jni/FFmpegWrapper.c
@@ -408,7 +408,7 @@ void Java_net_openwatch_ffmpegwrapper_FFmpegWrapper_writeAVPacketFromEncodedData
 
     packet->size = (int) jSize;
     packet->data = data;
-    packet->pts = (int) jPts;
+    packet->pts = (int64_) jPts;
 
 	packet->pts = av_rescale_q(packet->pts, *videoSourceTimeBase, (outputFormatContext->streams[packet->stream_index]->time_base));
 


### PR DESCRIPTION
The line in 411 can cause errors for large values of numbers when tried to type cast to int. So using a 64- int fixes the issue.
